### PR TITLE
Add SimpleChat agent type and factory support

### DIFF
--- a/src/backend/kernel_agents/agent_factory.py
+++ b/src/backend/kernel_agents/agent_factory.py
@@ -20,6 +20,7 @@ from kernel_agents.planner_agent import PlannerAgent  # Add PlannerAgent import
 from kernel_agents.procurement_agent import ProcurementAgent
 from kernel_agents.product_agent import ProductAgent
 from kernel_agents.tech_support_agent import TechSupportAgent
+from kernel_agents.simple_chat_agent import SimpleChatAgent
 from models.messages_kernel import AgentType, PlannerResponsePlan
 # pylint:disable=E0611
 from semantic_kernel.agents.azure_ai.azure_ai_agent import AzureAIAgent
@@ -41,6 +42,7 @@ class AgentFactory:
         AgentType.HUMAN: HumanAgent,
         AgentType.PLANNER: PlannerAgent,
         AgentType.GROUP_CHAT_MANAGER: GroupChatManager,  # Add GroupChatManager
+        AgentType.SIMPLE_CHAT: SimpleChatAgent,
     }
 
     # Mapping of agent types to their string identifiers (for automatic tool loading)
@@ -54,6 +56,7 @@ class AgentFactory:
         AgentType.HUMAN: AgentType.HUMAN.value,
         AgentType.PLANNER: AgentType.PLANNER.value,
         AgentType.GROUP_CHAT_MANAGER: AgentType.GROUP_CHAT_MANAGER.value,
+        AgentType.SIMPLE_CHAT: AgentType.SIMPLE_CHAT.value,
     }
 
     # System messages for each agent type
@@ -67,6 +70,7 @@ class AgentFactory:
         AgentType.HUMAN: HumanAgent.default_system_message(),
         AgentType.PLANNER: PlannerAgent.default_system_message(),
         AgentType.GROUP_CHAT_MANAGER: GroupChatManager.default_system_message(),
+        AgentType.SIMPLE_CHAT: SimpleChatAgent.default_system_message(),
     }
 
     # Cache of agent instances by session_id and agent_type

--- a/src/backend/kernel_agents/simple_chat_agent.py
+++ b/src/backend/kernel_agents/simple_chat_agent.py
@@ -1,0 +1,11 @@
+from kernel_agents.generic_agent import GenericAgent
+from models.messages_kernel import AgentType
+
+
+class SimpleChatAgent(GenericAgent):
+    """Agent for basic conversational interactions."""
+
+    @staticmethod
+    def default_system_message(agent_name: str = AgentType.SIMPLE_CHAT.value) -> str:
+        """Get the default system message for the SimpleChatAgent."""
+        return "You are a Simple Chat agent that engages in basic conversation and provides helpful responses."

--- a/src/backend/models/messages_kernel.py
+++ b/src/backend/models/messages_kernel.py
@@ -48,6 +48,7 @@ class AgentType(str, Enum):
     TECH_SUPPORT = "Tech_Support_Agent"
     GROUP_CHAT_MANAGER = "Group_Chat_Manager"
     PLANNER = "Planner_Agent"
+    SIMPLE_CHAT = "Simple_Chat_Agent"
 
     # Add other agents as needed
 


### PR DESCRIPTION
## Summary
- add `SIMPLE_CHAT` option to `AgentType`
- implement `SimpleChatAgent` subclass of `GenericAgent`
- wire `SimpleChatAgent` into `AgentFactory` mappings

## Testing
- `python -m py_compile src/backend/models/messages_kernel.py src/backend/kernel_agents/agent_factory.py src/backend/kernel_agents/simple_chat_agent.py`
- `pytest -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_689742b44020832895d1ded170d81dde