### PR TITLE
Add chat navigation option

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import './App.css';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { HomePage, PlanPage } from './pages';
+import { HomePage, PlanPage, ChatPage } from './pages';
 
 function App() {
   return (
@@ -9,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/plan/:planId" element={<PlanPage />} />
+        <Route path="/chat" element={<ChatPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </Router>

--- a/src/frontend/src/components/content/PlanPanelLeft.tsx
+++ b/src/frontend/src/components/content/PlanPanelLeft.tsx
@@ -2,9 +2,6 @@ import PanelLeft from "@/coral/components/Panels/PanelLeft";
 import PanelLeftToolbar from "@/coral/components/Panels/PanelLeftToolbar";
 import {
   Body1Strong,
-  Button,
-  Subtitle1,
-  Subtitle2,
   Toast,
   ToastBody,
   ToastTitle,
@@ -12,8 +9,8 @@ import {
   useToastController,
 } from "@fluentui/react-components";
 import {
-  Add20Regular,
   ChatAdd20Regular,
+  Chat20Regular,
   ErrorCircle20Regular,
 } from "@fluentui/react-icons";
 import TaskList from "./TaskList";
@@ -140,6 +137,25 @@ const PlanPanelLeft: React.FC<PlanPanelLefProps> = ({ reloadTasks,restReload }) 
             <ChatAdd20Regular />
           </div>
           <Body1Strong>New task</Body1Strong>
+        </div>
+
+        <br />
+        <div
+          className="tab tab-chat"
+          onClick={() => navigate("/chat")}
+          tabIndex={0}
+          role="button"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              navigate("/chat");
+            }
+          }}
+        >
+          <div className="tab tab-chat-icon">
+            <Chat20Regular />
+          </div>
+          <Body1Strong>Chat</Body1Strong>
         </div>
 
         <br />

--- a/src/frontend/src/pages/ChatPage.tsx
+++ b/src/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import Chat from "@/components/Chat";
+
+const ChatPage: React.FC = () => {
+  return <Chat />;
+};
+
+export default ChatPage;

--- a/src/frontend/src/pages/index.tsx
+++ b/src/frontend/src/pages/index.tsx
@@ -1,2 +1,3 @@
 export { default as HomePage } from './HomePage';
 export { default as PlanPage } from './PlanPage';
+export { default as ChatPage } from './ChatPage';

--- a/src/frontend/src/styles/PlanPanelLeft.css
+++ b/src/frontend/src/styles/PlanPanelLeft.css
@@ -39,6 +39,21 @@ background: radial-gradient(circle, rgba(238, 174, 221, 1) 0%, rgba(117, 121, 23
 color: #2F2F4A; */
 }
 
+.tab.tab-chat {
+  margin: 0px 8px;
+}
+
+.tab.tab-chat-icon {
+  display: flex;
+  width: 40px;
+  height: 40px;
+  background-color: var(--colorNeutralBackground1);
+  justify-content: center;
+  align-items: center;
+  border-radius: 16px;
+  box-sizing: border-box;
+}
+
 /* TASKLIST */
 
 .task-tab {


### PR DESCRIPTION
## Summary
- link to new Chat page from PlanPanelLeft navigation
- style sidebar chat entry
- create ChatPage and route /chat

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "react-app")*
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68974e928c7483288c61476b9a2efdcd